### PR TITLE
Update header search results layout

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -704,46 +704,169 @@ document.addEventListener('DOMContentLoaded', function() {
         resultsContainer.innerHTML = '<div class="no-results-message">Searching...</div>';
         resultsContainer.style.display = 'block';
 
-        // 尝试不同路径加载search.json
         const searchPaths = ['{{ site.baseurl }}/search.json', './search.json', '/search.json', 'search.json'];
-
-        for (let i = 0; i < searchPaths.length; i++) {
-          try {
-            const response = await fetch(searchPaths[i]);
-            if (response.ok) {
-              const text = await response.text();
-              let data;
-              try {
-                data = JSON.parse(text);
-              } catch (parseError) {
-                console.warn('JSON解析错误，尝试清理数据:', parseError);
-                // 尝试清理数据
-                const jsonStart = text.indexOf('[');
-                if (jsonStart !== -1) {
-                  const cleanedText = text.substring(jsonStart);
-                  data = JSON.parse(cleanedText);
-                } else {
-                  throw parseError;
-                }
-              }
-              this.processSearchResults(data, query);
-              return;
-            }
-          } catch (error) {
-            console.error('搜索路径错误:', searchPaths[i], error);
-          }
+        try {
+          let data = await SearchUtils.fetchData(searchPaths);
+          data = this.enhanceRecords(data);
+          this.processSearchResults(data, query);
+        } catch (err) {
+          console.error('搜索数据加载失败:', err);
+          resultsContainer.innerHTML = '<div class="no-results-message">Unable to load search data, please try the standalone search page</div>';
         }
-
-        // 如果所有路径都失败
-        resultsContainer.innerHTML = '<div class="no-results-message">Unable to load search data, please try the standalone search page</div>';
       },
 
       processSearchResults(data, query) {
-        
+
         // 限制结果数量
         const results = SearchUtils.processResults(data, query);
         const limitedResults = results.slice(0, 1000);
         this.renderResults(limitedResults, query);
+      },
+
+      enhanceRecords(records) {
+        return records.map(item => {
+          if (!item.result_type) {
+            item.result_type = item.is_sequence ? 'sequence' : 'page';
+          }
+          const rawTags = item.meta_tags || item.tags;
+          if (rawTags) {
+            const tagMap = this.parseTagsToMap(rawTags);
+            item.structured_tags = tagMap;
+            if (!item.target_type && tagMap['Type']) item.target_type = tagMap['Type'];
+            if (!item.pub_year && tagMap['Year']) item.pub_year = parseInt(tagMap['Year']);
+
+            const lenMatches = rawTags.match(/Length\s*:\s*(\d+)/gi);
+            if (lenMatches && lenMatches.length) {
+              const vals = lenMatches.map(m => parseInt(m.split(':')[1])).filter(v => !isNaN(v));
+              if (vals.length) {
+                const min = Math.min(...vals);
+                const max = Math.max(...vals);
+                if (!item.sequence_length) item.sequence_length = min;
+                item.sequence_length_range = min === max ? `${min}` : `${min}-${max}`;
+              }
+            }
+
+            const gcMatches = rawTags.match(/GC\s*:\s*([\d\.]+)/gi);
+            if (gcMatches && gcMatches.length) {
+              const vals = gcMatches.map(m => parseFloat(m.split(':')[1])).filter(v => !isNaN(v));
+              if (vals.length) {
+                const min = Math.min(...vals);
+                const max = Math.max(...vals);
+                const gcVal = Number(min.toFixed(2));
+                if (item.gc_content === undefined) item.gc_content = gcVal;
+                item.gc_content_range = min === max ? `${gcVal}` : `${min.toFixed(2)}-${max.toFixed(2)}`;
+              }
+            }
+
+          if (tagMap['Category'] && !item.category_value) item.category_value = tagMap['Category'];
+
+          const namedMatches = (item.meta_tags || rawTags).match(/Named\s*:/gi);
+          if (namedMatches && namedMatches.length) {
+            item.aptamer_count = namedMatches.length;
+          }
+        }
+        return item;
+      });
+      },
+
+      parseTagsToMap(tagsStr) {
+        if (!tagsStr) return {};
+        const tagMap = {};
+        if (tagsStr.includes('Category:') || tagsStr.includes('Type:')) {
+          const tagLines = tagsStr.split(/\n|,/).filter(line => line.trim());
+          tagLines.forEach(line => {
+            const cleanLine = line.replace(/^\s*-\s*/, '').trim();
+            const colonMatch = cleanLine.match(/^([^:]+):\s*(.+)$/);
+            if (colonMatch) {
+              const [, key, value] = colonMatch;
+              const keyTrimmed = key.trim();
+              if (tagMap[keyTrimmed] === undefined) {
+                tagMap[keyTrimmed] = value.trim();
+              }
+            } else if (cleanLine) {
+              tagMap[cleanLine] = true;
+            }
+          });
+          return tagMap;
+        }
+
+        const tagItems = tagsStr.split(/,\s*/g);
+        tagItems.forEach(tag => {
+          const colonMatch = tag.match(/^([^:]+):\s*(.+)$/);
+          if (colonMatch) {
+            const [, key, value] = colonMatch;
+            tagMap[key.trim()] = value.trim();
+            return;
+          }
+          tagMap[tag.trim()] = true;
+        });
+        return tagMap;
+      },
+
+      generateSequenceSearchQuery(item) {
+        if (item.structured_tags && item.structured_tags['Ligand']) {
+          return item.structured_tags['Ligand'];
+        }
+        if (item.content && item.content.includes('Ligand:')) {
+          const m = item.content.match(/Ligand:\s*([^|,]+)/i);
+          if (m && m[1]) return m[1].trim();
+        }
+        if (item.title) {
+          let titleQuery = item.title
+            .replace(/\s*aptamer\s*/gi, ' ')
+            .replace(/\s*binding\s*/gi, ' ')
+            .replace(/\s*RNA\s*/gi, ' ')
+            .replace(/\s*DNA\s*/gi, ' ')
+            .replace(/\s*sequence\s*/gi, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+          const words = titleQuery.split(' ').filter(w => w.length > 2);
+          if (words.length) return words.slice(0, 2).join(' ');
+        }
+        if (item.structured_tags && item.structured_tags['Type']) {
+          return item.structured_tags['Type'];
+        }
+        return item.title ? item.title.split(' ').slice(0, 2).join(' ') : 'aptamer';
+      },
+
+      setupSequencesAccessHandlers(container) {
+        if (this.sequencesAccessHandler) {
+          container.removeEventListener('click', this.sequencesAccessHandler);
+        }
+        this.sequencesAccessHandler = (event) => {
+          const btn = event.target.closest('.tag-sequences-btn');
+          if (!btn) return;
+          event.preventDefault();
+          event.stopPropagation();
+          const searchQuery = btn.getAttribute('data-search-query');
+          if (searchQuery) {
+            const url = `/sequences/?search=${encodeURIComponent(searchQuery)}`;
+            window.open(url, '_blank');
+          }
+        };
+        container.addEventListener('click', this.sequencesAccessHandler);
+      },
+
+      setupSequenceToggleHandlers(container) {
+        container.removeEventListener('click', this.sequenceToggleHandler);
+        this.sequenceToggleHandler = (e) => {
+          if (!e.target.classList.contains('btn-toggle-sequence')) return;
+          e.preventDefault();
+          e.stopPropagation();
+          const btn = e.target;
+          const seqContainer = btn.closest('.sequence-content');
+          const fullSequence = btn.getAttribute('data-full');
+          if (!fullSequence) return;
+          const isMore = btn.textContent.includes('Show more') || btn.textContent.includes('Show full');
+          if (isMore) {
+            const isMatchView = btn.closest('.sequence-matched') !== null;
+            seqContainer.innerHTML = `<div class="sequence-info-row"><strong>Sequence:</strong><span class="sequence-text">${fullSequence}</span><button class="btn-toggle-sequence" data-full="${fullSequence}" data-mode="${isMatchView ? 'match' : 'truncate'}">Show less</button></div>`;
+          } else {
+            const truncated = fullSequence.substring(0, 40);
+            seqContainer.innerHTML = `<div class="sequence-info-row"><strong>Sequence:</strong><span class="sequence-text">${truncated}...</span><button class="btn-toggle-sequence" data-full="${fullSequence}">Show more</button></div>`;
+          }
+        };
+        container.addEventListener('click', this.sequenceToggleHandler);
       },
 
              currentPage: 1,
@@ -769,19 +892,120 @@ document.addEventListener('DOMContentLoaded', function() {
          const endIndex = Math.min(startIndex + this.resultsPerPage, this.allResults.length);
          const currentResults = this.allResults.slice(startIndex, endIndex);
 
-         let html = '';
-         currentResults.forEach((item, index) => {
-           const highlightedTitle = this.highlightKeywords(item.title || 'Untitled', query);
-           const contentPreview = this.getContentPreview(item.content || '', query);
-           
-           html += `<div class="result-item-list search-result-item result-page" onclick="window.open('${item.url}', '_blank')">
-             <div class="result-header">
-               <span class="result-index">${startIndex + index + 1}</span>
-               <h3 class="result-title"><a href="${item.url}" target="_blank">${highlightedTitle}</a></h3>
-             </div>
-             <div class="result-description">${contentPreview}</div>
-           </div>`;
-         });
+        let html = '';
+        currentResults.forEach((item, index) => {
+          const highlightedTitle = this.highlightKeywords(item.title || 'Untitled', query);
+          let contentPreview = '';
+          if (item.content) {
+            if (item.result_type === 'sequence' && item.content.includes('Sequence:')) {
+              const seqMatch = item.content.match(/Sequence:\s*([ACGTU\s]+)/i);
+              if (seqMatch && seqMatch[1]) {
+                const sequence = seqMatch[1].trim();
+                const maxVisibleLength = 40;
+                const isSearchingSequence = query && /[ACGTU]{2,}/i.test(query);
+                if (isSearchingSequence) {
+                  const queryRegex = new RegExp(query.replace(/[ACGTU]+/ig, m => m.split('').join('[\\s]*')), 'ig');
+                  let match; const matches = [];
+                  while ((match = queryRegex.exec(sequence)) !== null) {
+                    matches.push({ index: match.index, length: match[0].length, text: match[0] });
+                  }
+                  if (matches.length > 0) {
+                    const firstMatch = matches[0];
+                    const contextBefore = 10, contextAfter = 10;
+                    const startIdx = Math.max(0, firstMatch.index - contextBefore);
+                    const endIdx = Math.min(sequence.length, firstMatch.index + firstMatch.length + contextAfter);
+                    const before = sequence.substring(startIdx, firstMatch.index);
+                    const matchText = sequence.substring(firstMatch.index, firstMatch.index + firstMatch.length);
+                    const after = sequence.substring(firstMatch.index + firstMatch.length, endIdx);
+                    const displaySeq = `${startIdx > 0 ? '...' : ''}${before}<span class="sequence-match">${matchText}</span>${after}${endIdx < sequence.length ? '...' : ''}`;
+                    contentPreview = `<div class="sequence-content"><div class="sequence-info-row"><strong>Sequence Match:</strong><span class="sequence-text">${displaySeq}</span><button class="btn-toggle-sequence" data-full="${sequence}">Show full</button></div>`;
+                  } else if (sequence.length > maxVisibleLength) {
+                    contentPreview = `<div class="sequence-content"><div class="sequence-info-row"><strong>Sequence:</strong><span class="sequence-text">${sequence.substring(0, maxVisibleLength)}...</span><button class="btn-toggle-sequence" data-full="${sequence}">Show more</button></div>`;
+                  } else {
+                    contentPreview = `<div class="sequence-content"><div class="sequence-info-row"><strong>Sequence:</strong><span class="sequence-text">${sequence}</span></div>`;
+                  }
+
+                  const info = [];
+                  if (item.named && item.named.trim()) {
+                    info.push(`<strong>Sequence Name:</strong> ${this.highlightKeywords(item.named.trim(), query)}`);
+                  }
+                  if (item.content.includes('Ligand:')) {
+                    const lm = item.content.match(/Ligand:\s*([^|]+)/i); if (lm && lm[1]) info.push(`<strong>Ligand:</strong> ${this.highlightKeywords(lm[1].trim(), query)}`);
+                  }
+                  if (info.length >= 2) {
+                    contentPreview += `<div class="sequence-info-row">${info.slice(0,2).join(' | ')}</div>`;
+                    for (let i=2;i<info.length;i++) contentPreview += `<div class="sequence-info-row">${info[i]}</div>`;
+                  } else if (info.length === 1) {
+                    contentPreview += `<div class="sequence-info-row">${info[0]}</div>`;
+                  }
+                  if (item.content.includes('Affinity:')) {
+                    const am = item.content.match(/Affinity:\s*([^|]+)/i); if (am && am[1]) contentPreview += `<div class="sequence-info-row"><strong>Affinity:</strong> ${this.highlightKeywords(am[1].trim(), query)}</div>`;
+                  }
+                  contentPreview += `</div>`;
+                } else if (sequence.length > maxVisibleLength) {
+                  contentPreview = `<div class="sequence-content"><div class="sequence-info-row"><strong>Sequence:</strong><span class="sequence-text">${sequence.substring(0, maxVisibleLength)}...</span><button class="btn-toggle-sequence" data-full="${sequence}">Show more</button></div></div>`;
+                } else {
+                  contentPreview = `<div class="sequence-content"><div class="sequence-info-row"><strong>Sequence:</strong><span class="sequence-text">${sequence}</span></div></div>`;
+                }
+              } else {
+                contentPreview = this.getContentPreview(item.content, query);
+              }
+            } else {
+              contentPreview = this.getContentPreview(item.content, query);
+            }
+          }
+
+          // ===== Tags (show Target type and multi-aptamer flag) =====
+          const tags = [];
+          if (item.structured_tags && item.structured_tags['Type']) {
+            tags.push(`<span class="tag tag-type">Target: ${item.structured_tags['Type']}</span>`);
+          } else if (item.tags && item.tags.includes('Type:')) {
+            const typeMatch = item.tags.match(/Type:([^,]+)/i);
+            if (typeMatch && typeMatch[1]) {
+              tags.push(`<span class="tag tag-type">Target: ${typeMatch[1].trim()}</span>`);
+            }
+          }
+          if (item.result_type === 'page' && item.aptamer_count) {
+            const searchQuery = this.generateSequenceSearchQuery(item);
+            const label = item.aptamer_count > 1 ? `${item.aptamer_count} Sequences` : '1 Sequence';
+            tags.push(`<button class="tag tag-sequences-btn" data-search-query="${searchQuery}" title="View all ${item.aptamer_count} sequences from this page"><i class="fas fa-dna"></i> ${label}</button>`);
+          }
+
+          // ===== Meta information =====
+          const metaItems = [];
+          const yearInfo = item.pub_year || (item.date ? item.date.split('-')[0] : 'Unknown');
+          metaItems.push(`<span class="meta-item"><i class="fas fa-calendar"></i> Year: ${yearInfo}</span>`);
+
+          if (item.sequence_length_range) {
+            metaItems.push(`<span class="meta-item"><i class="fas fa-ruler"></i> Length: ${item.sequence_length_range} bp</span>`);
+          } else if (item.sequence_length) {
+            metaItems.push(`<span class="meta-item"><i class="fas fa-ruler"></i> Length: ${item.sequence_length} bp</span>`);
+          }
+
+          if (item.gc_content_range) {
+            metaItems.push(`<span class="meta-item"><i class="fas fa-percentage"></i> GC: ${item.gc_content_range}%</span>`);
+          } else if (item.gc_content !== undefined) {
+            metaItems.push(`<span class="meta-item"><i class="fas fa-percentage"></i> GC: ${item.gc_content}%</span>`);
+          }
+
+          let typeIcon = 'fa-file-alt';
+          let typeLabel = 'Page';
+          if (item.result_type === 'sequence') {
+            typeIcon = 'fa-dna';
+            typeLabel = 'Sequence';
+          }
+          metaItems.push(`<span class="meta-item result-type"><i class="fas ${typeIcon}"></i> ${typeLabel}</span>`);
+
+          html += `<div class="result-item-list ${item.result_type === 'sequence' ? 'result-sequence' : 'result-page'}" onclick="window.open('${item.url}', '_blank')">
+            <div class="result-header">
+              <span class="result-index">${startIndex + index + 1}</span>
+              <h3 class="result-title"><a href="${item.url}" target="_blank">${highlightedTitle}</a></h3>
+              <div class="result-tags">${tags.join('')}</div>
+            </div>
+            <div class="result-meta">${metaItems.join('')}</div>
+            <div class="result-description">${contentPreview}</div>
+          </div>`;
+        });
 
          // 添加分页控件
          if (totalPages > 1) {
@@ -820,7 +1044,9 @@ document.addEventListener('DOMContentLoaded', function() {
          }
 
          resultsContainer.innerHTML = html;
-       },
+         this.setupSequenceToggleHandlers(resultsContainer);
+         this.setupSequencesAccessHandlers(resultsContainer);
+      },
 
        goToPage(page) {
          this.currentPage = page;

--- a/css/search-override.css
+++ b/css/search-override.css
@@ -146,4 +146,109 @@
 .search-results-overlay{
   background:transparent !important;
   backdrop-filter:none !important;
-} 
+} /* List style extras for header search */
+.result-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+.result-tags .tag {
+  background: #f0f0f0;
+  border-radius: 12px;
+  padding: 2px 8px;
+  font-size: 12px;
+  color: #333;
+}
+.result-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: #555;
+  margin-bottom: 6px;
+}
+.meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.meta-item i {
+  margin-right: 2px;
+}
+.tag-sequences-btn {
+  background: #0066cc;
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 3px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.tag-sequences-btn:hover {
+  background: #005bb5;
+}
+
+.sequence-info-row {
+  margin: 4px 0;
+  padding: 6px 12px;
+  background: rgba(0, 102, 204, 0.05);
+  border-radius: 6px;
+  border-left: 3px solid #0066cc;
+  font-size: 14px;
+  line-height: 1.4;
+  display: block;
+  min-height: 20px;
+}
+.sequence-info-row strong {
+  color: #0066cc;
+  font-weight: 600;
+  line-height: 1.4;
+}
+.sequence-text {
+  font-family: 'Courier New', monospace;
+  letter-spacing: 0.5px;
+  background-color: rgba(0, 102, 204, 0.1);
+  padding: 4px 8px;
+  border-radius: 3px;
+  display: inline-block;
+  margin: 0 4px 0 0;
+  max-width: calc(100% - 120px);
+  overflow-x: auto;
+  white-space: normal;
+  word-break: break-all;
+  line-height: 1.4;
+  vertical-align: middle;
+  border: 1px solid rgba(0, 102, 204, 0.2);
+  color: #333;
+}
+.sequence-content {
+  margin-top: 6px;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  line-height: 1.4;
+}
+.btn-toggle-sequence {
+  background: #0066cc;
+  color: white;
+  border: none;
+  padding: 3px 8px;
+  border-radius: 3px;
+  font-size: 11px;
+  cursor: pointer;
+  margin-left: 8px;
+  transition: all 0.2s;
+  vertical-align: middle;
+  line-height: 1.2;
+}
+.btn-toggle-sequence:hover {
+  background: #0052a3;
+}
+.sequence-match {
+  background-color: #cce7ff;
+  color: #0066cc;
+  font-weight: bold;
+  padding: 0 2px;
+  border-radius: 2px;
+}


### PR DESCRIPTION
## Summary
- show detailed result metadata in header search
- style header search result list like advanced page
- parse tags correctly and include sequence records in header search results
- display sequence details and sequence counts like advanced search

## Testing
- `npm run test:minify`


------
https://chatgpt.com/codex/tasks/task_e_6886e1408c14832aadddd8beca8d5242